### PR TITLE
Fix/boolean filter fix

### DIFF
--- a/docs/filter-types/date.md
+++ b/docs/filter-types/date.md
@@ -60,22 +60,31 @@ Allowed modes are
 
 ## Modes with two values
 
-For using the between and not between filters you have to provide two values to the filter. Ordering
-of this values doesn't matter, the filter will detect if the first or second is the smaller one.
+For using the between and not between filters you have to provide two values to the filter. You can
+omit one of the values, if it shall not be applied. You can offer a between filter and
+only fill in the first or second value to get behaviour like a lower or greater filter. 
 
 For providing multiple values use the following query parameters
 
 ```
+# For FilterMode::BETWEEN
+# finds all between 2023-01-01 and 2023-01-10
 https://.../posts?test_date_filter[]=2023-01-01&test_date_filter[]=2023-01-10
+https://.../posts?test_date_filter[0]=2023-01-01&test_date_filter[1]=2023-01-10
+
+# finds all greater or equal than 2023-01-01
+https://.../posts?test_date_filter[0]=2023-01-01&test_date_filter[1]=
+
+# finds all smaller or equal then 2023-01-10
+https://.../posts?test_date_filter[0]=&test_date_filter[1]=2023-01-10
 ```
 
 or programmatically
 
 ```php
 Post::filter(['created_at_filter' => ['2023-01-01', '2023-01-10']])->get();
+Post::filter(['created_at_filter' => ['', '2023-01-10']])->get();
 ```
-
-This will find all posts created between or not between 1st and 10th of January.
 
 FilterMode::BETWEEN will include both days, FilterMode::BETWEEN_EXCLUSIVE will exclude both days.
 

--- a/docs/filter-types/numeric.md
+++ b/docs/filter-types/numeric.md
@@ -62,22 +62,31 @@ Allowed modes are
 
 ## Modes with two values
 
-For using between and not between filters you have to provide two values to the filter. Ordering
-of this values doesn't matter, the filter will detect if the first or second is the smaller one.
+For using between and not between filters you have to provide two values to the filter. You can 
+omit one of the values, if it shall not be applied. You can offer a between filter and
+only fill in the first or second value to get behaviour like a lower or greater filter. 
 
 For providing multiple values use the following query parameters
 
 ```
+# For FilterMode::BETWEEN
+# finds all between 100 and 1000
 https://.../posts?test_numeric_filter[]=100&test_date_filter[]=1000
+https://.../posts?test_numeric_filter[0]=100&test_date_filter[1]=1000
+
+# finds all greater or equal than 100
+https://.../posts?test_date_filter[0]=100
+
+# finds all smaller or equal than 1000
+https://.../posts?test_date_filter[1]=1000
 ```
 
 or programmatically
 
 ```php
 Post::filter(['test_numeric_filter' => [100, 1000]])->get();
+Post::filter(['test_numeric_filter' => ['', 1000]])->get();
 ```
-
-This will find all posts where fieldname is between 100 and 1000.
 
 FilterMode::BETWEEN will include both values, FilterMode::BETWEEN_EXCLUSIVE will exclude both values.
 

--- a/docs/filter-types/numeric.md
+++ b/docs/filter-types/numeric.md
@@ -75,10 +75,10 @@ https://.../posts?test_numeric_filter[]=100&test_date_filter[]=1000
 https://.../posts?test_numeric_filter[0]=100&test_date_filter[1]=1000
 
 # finds all greater or equal than 100
-https://.../posts?test_date_filter[0]=100
+https://.../posts?test_date_filter[0]=100&test_date_filter[1]=
 
 # finds all smaller or equal than 1000
-https://.../posts?test_date_filter[1]=1000
+https://.../posts?test_date_filter[0]=&test_date_filter[1]=1000
 ```
 
 or programmatically

--- a/src/Filters/DateFilter.php
+++ b/src/Filters/DateFilter.php
@@ -16,7 +16,7 @@ class DateFilter extends SingleFieldFilter
         parent::populate($values);
 
         $this->values = Arr::map($this->values, fn ($value) => is_array($value)
-            ? array_values(Arr::sort($value))
+            ? array_values($value)
             : $value);
 
         return $this;
@@ -31,23 +31,23 @@ class DateFilter extends SingleFieldFilter
             FilterMode::GREATER_OR_EQUAL => $query->where($this->field, '>=', $this->values[$this->field] . ' 00:00:00'),
             FilterMode::BETWEEN => $query->where(
                 fn (Builder $betweenQuery) => $betweenQuery
-                    ->where($this->field, '>=', $this->values[$this->field][0] . ' 00:00:00')
-                    ->where($this->field, '<=', $this->values[$this->field][1] . ' 23:59:59')
+                    ->when(! empty($this->values[$this->field][0]), fn ($q) => $q->where($this->field, '>=', $this->values[$this->field][0] . ' 00:00:00'))
+                    ->when(! empty($this->values[$this->field][1]), fn ($q) => $q->where($this->field, '<=', $this->values[$this->field][1] . ' 23:59:59'))
             ),
             FilterMode::BETWEEN_EXCLUSIVE => $query->where(
                 fn (Builder $betweenQuery) => $betweenQuery
-                    ->where($this->field, '>', $this->values[$this->field][0] . ' 23:59:59')
-                    ->where($this->field, '<', $this->values[$this->field][1] . ' 00:00:00')
+                    ->when(! empty($this->values[$this->field][0]), fn ($q) => $q->where($this->field, '>', $this->values[$this->field][0] . ' 23:59:59'))
+                    ->when(! empty($this->values[$this->field][1]), fn ($q) => $q->where($this->field, '<', $this->values[$this->field][1] . ' 00:00:00'))
             ),
             FilterMode::NOT_BETWEEN => $query->where(
                 fn (Builder $betweenQuery) => $betweenQuery
-                    ->orWhere($this->field, '<', $this->values[$this->field][0] . ' 00:00:00')
-                    ->orWhere($this->field, '>', $this->values[$this->field][1] . ' 23:59:59')
+                    ->when(! empty($this->values[$this->field][0]), fn ($q) => $q->orWhere($this->field, '<', $this->values[$this->field][0] . ' 00:00:00'))
+                    ->when(! empty($this->values[$this->field][1]), fn ($q) => $q->orWhere($this->field, '>', $this->values[$this->field][1] . ' 23:59:59'))
             ),
             FilterMode::NOT_BETWEEN_INCLUSIVE => $query->where(
                 fn (Builder $betweenQuery) => $betweenQuery
-                    ->orWhere($this->field, '<=', $this->values[$this->field][0] . ' 23:59:59')
-                    ->orWhere($this->field, '>=', $this->values[$this->field][1] . ' 00:00:00')
+                    ->when(! empty($this->values[$this->field][0]), fn ($q) => $q->orWhere($this->field, '<=', $this->values[$this->field][0] . ' 23:59:59'))
+                    ->when(! empty($this->values[$this->field][1]), fn ($q) => $q->orWhere($this->field, '>=', $this->values[$this->field][1] . ' 00:00:00'))
             ),
             default => $query->whereDate($this->field, $this->values[$this->field]),
         };

--- a/src/Filters/NumericFilter.php
+++ b/src/Filters/NumericFilter.php
@@ -18,7 +18,7 @@ class NumericFilter extends SingleFieldFilter
         parent::populate($values);
 
         $this->values = Arr::map($this->values, fn ($value) => is_array($value)
-            ? array_values(Arr::sort($value))
+            ? array_values($value)
             : $value);
 
         return $this;
@@ -33,23 +33,23 @@ class NumericFilter extends SingleFieldFilter
             FilterMode::GREATER_OR_EQUAL => $query->where($this->field, '>=', $this->values[$this->field]),
             FilterMode::BETWEEN => $query->where(
                 fn (Builder $betweenQuery) => $betweenQuery
-                    ->where($this->field, '>=', $this->values[$this->field][0])
-                    ->where($this->field, '<=', $this->values[$this->field][1])
+                    ->when(is_numeric($this->values[$this->field][0]), fn ($q) => $q->where($this->field, '>=', $this->values[$this->field][0]))
+                    ->when(is_numeric($this->values[$this->field][1]), fn ($q) => $q->where($this->field, '<=', $this->values[$this->field][1]))
             ),
             FilterMode::BETWEEN_EXCLUSIVE => $query->where(
                 fn (Builder $betweenQuery) => $betweenQuery
-                    ->where($this->field, '>', $this->values[$this->field][0])
-                    ->where($this->field, '<', $this->values[$this->field][1])
+                    ->when(is_numeric($this->values[$this->field][0]), fn ($q) => $q->where($this->field, '>', $this->values[$this->field][0]))
+                    ->when(is_numeric($this->values[$this->field][1]), fn ($q) => $q->where($this->field, '<', $this->values[$this->field][1]))
             ),
             FilterMode::NOT_BETWEEN => $query->where(
                 fn (Builder $betweenQuery) => $betweenQuery
-                    ->orWhere($this->field, '<', $this->values[$this->field][0])
-                    ->orWhere($this->field, '>', $this->values[$this->field][1])
+                    ->when(is_numeric($this->values[$this->field][0]), fn ($q) => $q->orWhere($this->field, '<', $this->values[$this->field][0]))
+                    ->when(is_numeric($this->values[$this->field][1]), fn ($q) => $q->orWhere($this->field, '>', $this->values[$this->field][1]))
             ),
             FilterMode::NOT_BETWEEN_INCLUSIVE => $query->where(
                 fn (Builder $betweenQuery) => $betweenQuery
-                    ->orWhere($this->field, '<=', $this->values[$this->field][0])
-                    ->orWhere($this->field, '>=', $this->values[$this->field][1])
+                    ->when(is_numeric($this->values[$this->field][0]), fn ($q) => $q->orWhere($this->field, '<=', $this->values[$this->field][0]))
+                    ->when(is_numeric($this->values[$this->field][1]), fn ($q) => $q->orWhere($this->field, '>=', $this->values[$this->field][1]))
             ),
             default => $query->where($this->field, $this->values[$this->field]),
         };

--- a/tests/Unit/DateFilterTest.php
+++ b/tests/Unit/DateFilterTest.php
@@ -67,13 +67,13 @@ it('can be filtered by date between', function () {
     ])->count())->toEqual(14);
 });
 
-it('can be filtered by date between with wrong order', function () {
+it('cannot be filtered by date between with wrong order', function () {
     expect(Post::filter([
         'created_at_between' => [
             Carbon::now()->addWeek()->format('Y-m-d'),
             Carbon::now()->subWeek()->format('Y-m-d'),
         ],
-    ])->count())->toEqual(14);
+    ])->count())->toEqual(0);
 });
 
 it('can be filtered by date between exclusive', function () {
@@ -94,13 +94,13 @@ it('can be filtered by date not between', function () {
     ])->count())->toEqual(25);
 });
 
-it('can be filtered by date not between with wrong order', function () {
+it('cannot be filtered by date not between with wrong order', function () {
     expect(Post::filter([
         'created_at_not_between' => [
             Carbon::now()->addWeek()->format('Y-m-d'),
             Carbon::now()->subWeek()->format('Y-m-d'),
         ],
-    ])->count())->toEqual(25);
+    ])->count())->toEqual(39);
 });
 
 it('can be filtered by date not between inclusive', function () {

--- a/tests/Unit/NumericFilterTest.php
+++ b/tests/Unit/NumericFilterTest.php
@@ -66,13 +66,13 @@ it('can be filtered by number between', function () {
     ])->count())->toEqual(14);
 });
 
-it('can be filtered by number between with wrong order', function () {
+it('cannot be filtered by number between with wrong order', function () {
     expect(Post::filter([
         'counter_between' => [
             14500,
             5500,
         ],
-    ])->count())->toEqual(14);
+    ])->count())->toEqual(0);
 });
 
 it('can be filtered by number between exclusive', function () {
@@ -93,13 +93,13 @@ it('can be filtered by number not between', function () {
     ])->count())->toEqual(25);
 });
 
-it('can be filtered by number not between with wrong order', function () {
+it('cannot be filtered by number not between with wrong order', function () {
     expect(Post::filter([
         'counter_not_between' => [
-            5500,
             14500,
+            5500,
         ],
-    ])->count())->toEqual(25);
+    ])->count())->toEqual(39); // finds all - <= 14500 or >= 5500
 });
 
 it('can be filtered by number not between inclusive', function () {


### PR DESCRIPTION
ATTENTION: this is a small breaking change, but since the package is quite new, we accept it in a minor version. Until Version 1.5.x the ordering of values for date and numeric between/not-between filters didn't matter. But this prevented the option to omit one of the vales.

It is much more usefull to omit one of the between values to get the behaviour of a greater or lower than filter.