### PR TITLE
feat(select): add nullable option to filter for NULL values

### DIFF
--- a/docs/filter-types/belongs_to.md
+++ b/docs/filter-types/belongs_to.md
@@ -72,6 +72,25 @@ situations you can overwrite the method `relationQuery`
     }
 ```
 
+## Filtering for NULL values
+
+Because a `belongsTo` foreign key is usually nullable, you often want to find records that
+are not related to anything. Like every select-based filter, the `BelongsToFilter` supports
+the `nullable()` option for this, which adds a dedicated "no relation" entry:
+
+```php
+protected bool $nullable = true;
+```
+
+or fluently when registering the filter:
+
+```php
+(new TestBelongsToFilter())->nullable(label: 'Without user');
+```
+
+See [Filtering for NULL values](select.md#filtering-for-null-values) on the select filter
+for the full details.
+
 ## Filter Modes
 
 - FilterMode::EQUAL

--- a/docs/filter-types/enum.md
+++ b/docs/filter-types/enum.md
@@ -114,6 +114,19 @@ EnumFilter::make('state')
     ->setSortedOptions(false);
 ```
 
+## Filtering for NULL values
+
+If the enum column is nullable, enable the `nullable()` option to add a dedicated entry that
+filters for records where the field is `NULL`:
+
+```php
+protected bool $nullable = true;
+```
+
+See [Filtering for NULL values](select.md#filtering-for-null-values) on the select filter
+for the full details. Note that when option sorting is enabled, the "none" entry is sorted
+together with the translated enum labels.
+
 ## Filter Modes
 
 Enum filters only have the EQUAL mode like SelectFilters.

--- a/docs/filter-types/select.md
+++ b/docs/filter-types/select.md
@@ -68,6 +68,49 @@ The keys are only used for visualisation in the select input fields.
     }
 ```
 
+## Filtering for NULL values
+
+Select-based filters (including `BelongsToFilter` and `EnumFilter`) only filter for the
+values returned by `options()`. Nullable columns that contain no value can therefore not
+be targeted out of the box, because there is no option representing "empty".
+
+Enable the `nullable()` option to add a dedicated entry that filters for records where the
+field is `NULL`:
+
+```php
+class TestSelectFilter extends SelectFilter
+{
+    protected string $field = 'fieldname';
+
+    protected bool $nullable = true;
+
+    public function options(): array
+    {
+        return ['value1', 'value2'];
+    }
+}
+```
+
+You can also enable it fluently when registering the filter, optionally with a custom label:
+
+```php
+(new TestSelectFilter())->nullable();
+(new TestSelectFilter())->nullable(label: 'Without value');
+```
+
+When enabled, an additional option with the reserved value `__null__` is exposed. Selecting
+it applies a `whereNull()` (or, in the multiselect modes, `orWhereNull()` /
+`whereNotNull()`) on the field. The label defaults to the translation
+`model-filter::filters.none` ("None" / "Keine") and can be overridden via the `label`
+argument of `nullable()`.
+
+> The added option is only rendered/validated through `optionsWithNull()`. Your own
+> `options()` implementation stays untouched and must **not** include the `__null__` value
+> itself. The reserved value `__null__` should not be used as a real option value.
+
+`nullable()` is opt-in and defaults to `false`, so existing filters keep their exact
+behaviour unless you turn it on.
+
 ## Multiselect modes
 
 If you want to give multiple values to filter for, you can set the mode to CONTAINS

--- a/resources/lang/de/filters.php
+++ b/resources/lang/de/filters.php
@@ -22,4 +22,6 @@ return [
     'start_in_timeframe' => 'Start innerhalb des Zeitraums',
     'never' => 'Niemals',
     'not_current' => 'Zur Zeit nicht',
+
+    'none' => 'Keine',
 ];

--- a/resources/lang/en/filters.php
+++ b/resources/lang/en/filters.php
@@ -22,4 +22,6 @@ return [
     'start_in_timeframe' => 'Start in timeframe',
     'never' => 'Never',
     'not_current' => 'Not current',
+
+    'none' => 'None',
 ];

--- a/resources/views/components/filters/select.blade.php
+++ b/resources/views/components/filters/select.blade.php
@@ -17,7 +17,7 @@
         @endif
     >
         <option value="">&mdash;</option>
-        @foreach ($filter->options() as $key => $option)
+        @foreach ($filter->optionsWithNull() as $key => $option)
             <option
                 value="{{ $option }}"
                 @selected($multiple

--- a/src/Filters/SelectFilter.php
+++ b/src/Filters/SelectFilter.php
@@ -16,27 +16,53 @@ class SelectFilter extends SingleFieldFilter
 {
     protected string $component = 'select';
 
+    protected bool $nullable = false;
+
+    protected string $nullValue = '__null__';
+
+    protected ?string $nullLabel = null;
+
     /**
-     * @param  Builder<TModel> $query
+     * Add an explicit option to filter for records where the field is NULL.
+     */
+    public function nullable(bool $nullable = true, ?string $label = null): static
+    {
+        $this->nullable = $nullable;
+        $this->nullLabel = $label;
+
+        return $this;
+    }
+
+    public function isNullable(): bool
+    {
+        return $this->nullable;
+    }
+
+    /**
+     * The options as shown/selectable in the filter, including the optional
+     * "is null" option. Use this instead of options() for rendering and validation.
      *
+     * @return array<int|string, mixed>
+     */
+    public function optionsWithNull(): array
+    {
+        if (! $this->nullable) {
+            return $this->options();
+        }
+
+        return [$this->nullOptionLabel() => $this->nullValue] + $this->options();
+    }
+
+    /**
+     * @param  Builder<TModel>  $query
      * @return Builder<TModel>
      */
     public function applyFilter(Builder $query): Builder
     {
         return match ($this->mode) {
-            FilterMode::CONTAINS => $query->whereIn(
-                $this->getQualifiedField(),
-                array_intersect(Arr::wrap($this->getValue()), $this->options())
-            ),
-            FilterMode::NOT_CONTAINS => $query->whereNotIn(
-                $this->getQualifiedField(),
-                array_intersect(Arr::wrap($this->getValue()), $this->options())
-            ),
-            default => $query
-                ->when(
-                    in_array($this->getValue(), $this->options()),
-                    fn ($query) => $query->where($this->getQualifiedField(), $this->getValue())
-                ),
+            FilterMode::CONTAINS => $this->applyContains($query, negate: false),
+            FilterMode::NOT_CONTAINS => $this->applyContains($query, negate: true),
+            default => $this->applyEqual($query),
         };
     }
 
@@ -47,10 +73,53 @@ class SelectFilter extends SingleFieldFilter
             : $this->singleRules();
     }
 
+    /**
+     * @param  Builder<TModel>  $query
+     * @return Builder<TModel>
+     */
+    protected function applyEqual(Builder $query): Builder
+    {
+        if ($this->nullable && $this->getValue() === $this->nullValue) {
+            return $query->whereNull($this->getQualifiedField());
+        }
+
+        return $query->when(
+            in_array($this->getValue(), $this->options()),
+            fn ($query) => $query->where($this->getQualifiedField(), $this->getValue())
+        );
+    }
+
+    /**
+     * @param  Builder<TModel>  $query
+     * @return Builder<TModel>
+     */
+    protected function applyContains(Builder $query, bool $negate): Builder
+    {
+        $values = Arr::wrap($this->getValue());
+        $realValues = array_intersect($values, $this->options());
+        $includesNull = $this->nullable && in_array($this->nullValue, $values, true);
+
+        $field = $this->getQualifiedField();
+
+        if (! $includesNull) {
+            return $negate
+                ? $query->whereNotIn($field, $realValues)
+                : $query->whereIn($field, $realValues);
+        }
+
+        return $query->where(function (Builder $query) use ($field, $realValues, $negate): void {
+            if ($negate) {
+                $query->whereNotIn($field, $realValues)->whereNotNull($field);
+            } else {
+                $query->whereIn($field, $realValues)->orWhereNull($field);
+            }
+        });
+    }
+
     protected function singleRules(): array
     {
         return [
-            $this->queryName() => 'in:' . implode(',', $this->options()),
+            $this->queryName() => 'in:'.implode(',', $this->optionsWithNull()),
         ];
     }
 
@@ -58,7 +127,12 @@ class SelectFilter extends SingleFieldFilter
     {
         return [
             $this->queryName() => 'array',
-            $this->queryName() . '.*' => 'in:' . implode(',', $this->options()),
+            $this->queryName().'.*' => 'in:'.implode(',', $this->optionsWithNull()),
         ];
+    }
+
+    protected function nullOptionLabel(): string
+    {
+        return $this->nullLabel ?? trans('model-filter::filters.none');
     }
 }

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -89,22 +89,39 @@ class Post extends Model
                 ->setMode(FilterMode::BETWEEN)
                 ->setValidationMode(ValidationMode::THROW),
 
-            new TypeFilter(),
+            new TypeFilter,
 
-            (new TypeFilter())
+            (new TypeFilter)
                 ->setTitle(ucwords(str_replace('_', ' ', 'type_filter_throws')))
                 ->setQueryName('type_filter_throws')
                 ->setValidationMode(ValidationMode::THROW),
 
-            (new TypeFilter())
+            (new TypeFilter)
                 ->setTitle(ucwords(str_replace('_', ' ', 'type_multi')))
                 ->setQueryName('type_multi')
                 ->setMode(FilterMode::CONTAINS),
 
-            (new TypeFilter())
+            (new TypeFilter)
                 ->setTitle(ucwords(str_replace('_', ' ', 'type_not_contains')))
                 ->setQueryName('type_not_contains')
                 ->setMode(FilterMode::NOT_CONTAINS),
+
+            (new TypeFilter)
+                ->setTitle(ucwords(str_replace('_', ' ', 'type_nullable')))
+                ->setQueryName('type_nullable')
+                ->nullable(),
+
+            (new TypeFilter)
+                ->setTitle(ucwords(str_replace('_', ' ', 'type_nullable_multi')))
+                ->setQueryName('type_nullable_multi')
+                ->setMode(FilterMode::CONTAINS)
+                ->nullable(),
+
+            (new TypeFilter)
+                ->setTitle(ucwords(str_replace('_', ' ', 'type_nullable_not_contains')))
+                ->setQueryName('type_nullable_not_contains')
+                ->setMode(FilterMode::NOT_CONTAINS)
+                ->nullable(),
 
             (new StringFilter('title'))
                 ->setTitle(ucwords(str_replace('_', ' ', 'starts_with')))
@@ -130,7 +147,7 @@ class Post extends Model
                 ->setTitle(ucwords(str_replace('_', ' ', 'boolfilter')))
                 ->setQueryName('boolfilter'),
 
-            new IndividualFilter(),
+            new IndividualFilter,
 
             (new NumericFilter('counter'))
                 ->setTitle(ucwords(str_replace('_', ' ', 'counter_lower_filter')))
@@ -178,38 +195,38 @@ class Post extends Model
                 ->setMode(FilterMode::BETWEEN)
                 ->setValidationMode(ValidationMode::THROW),
 
-            new CounterFilter(),
+            new CounterFilter,
 
-            new TagFilter(),
+            new TagFilter,
 
-            (new TagFilter())
+            (new TagFilter)
                 ->setTitle(ucwords(str_replace('_', ' ', 'tag_filter_contains')))
                 ->setQueryName('tag_filter_contains')
                 ->setMode(FilterMode::CONTAINS),
 
-            (new TagFilter())
+            (new TagFilter)
                 ->setTitle(ucwords(str_replace('_', ' ', 'tag_filter_not_contains')))
                 ->setQueryName('tag_filter_not_contains')
                 ->setMode(FilterMode::NOT_CONTAINS),
 
-            new TagTimeframeFilter(),
+            new TagTimeframeFilter,
 
-            (new TagTimeframeFilter())
+            (new TagTimeframeFilter)
                 ->setTitle(ucwords(str_replace('_', ' ', 'tag_timeframe_filter_contains')))
                 ->setQueryName('tag_timeframe_filter_contains')
                 ->setMode(FilterMode::CONTAINS),
 
-            (new TagTimeframeFilter())
+            (new TagTimeframeFilter)
                 ->setTitle(ucwords(str_replace('_', ' ', 'tag_timeframe_filter_not_contains')))
                 ->setQueryName('tag_timeframe_filter_not_contains')
                 ->setMode(FilterMode::NOT_CONTAINS),
 
-            (new TagTimeframeFilter())
+            (new TagTimeframeFilter)
                 ->setTitle(ucwords(str_replace('_', ' ', 'tag_timeframe_filter_day')))
                 ->setQueryName('tag_timeframe_filter_day')
                 ->setPrecision(TimeframeFilterPrecision::DAY),
 
-            (new TagTimeframeFilter())
+            (new TagTimeframeFilter)
                 ->setTitle(ucwords(str_replace('_', ' ', 'tag_timeframe_filter_year')))
                 ->setQueryName('tag_timeframe_filter_year')
                 ->setPrecision(TimeframeFilterPrecision::YEAR),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,8 +13,8 @@ use Lacodix\LaravelModelFilter\LaravelModelFilterServiceProvider;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
-    use LazilyRefreshDatabase;
     use InteractsWithViews;
+    use LazilyRefreshDatabase;
     use WithFaker;
 
     protected function setUp(): void
@@ -36,7 +36,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         Capsule::schema()->create('posts', function (Blueprint $table) {
             $table->id();
             $table->string('title');
-            $table->string('type');
+            $table->string('type')->nullable();
             $table->boolean('published');
             $table->text('content');
             $table->integer('counter');

--- a/tests/Unit/SelectFilterNullableTest.php
+++ b/tests/Unit/SelectFilterNullableTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Lacodix\LaravelModelFilter\Filters\SelectFilter;
+use Tests\Filters\TypeFilter;
+use Tests\Models\Post;
+
+beforeEach(function () {
+    Post::factory()->state(['type' => 'page'])->count(15)->create();
+    Post::factory()->state(['type' => 'post'])->count(10)->create();
+    Post::factory()->state(['type' => null])->count(5)->create();
+});
+
+it('filters records where the field is null', function () {
+    expect(Post::filter(['type_nullable' => '__null__'])->count())->toEqual(5);
+});
+
+it('still filters by regular values when nullable is enabled', function () {
+    expect(Post::filter(['type_nullable' => 'page'])->count())->toEqual(15)
+        ->and(Post::filter(['type_nullable' => 'post'])->count())->toEqual(10);
+});
+
+it('does not treat the null sentinel specially when filter is not nullable', function () {
+    // type_filter is not nullable, the sentinel is invalid and therefore skipped
+    expect(Post::filter(['type_filter' => '__null__'])->count())->toEqual(30);
+});
+
+it('filters null values in contains mode', function () {
+    expect(Post::filter(['type_nullable_multi' => ['__null__']])->count())->toEqual(5)
+        ->and(Post::filter(['type_nullable_multi' => ['page', '__null__']])->count())->toEqual(20)
+        ->and(Post::filter(['type_nullable_multi' => ['page']])->count())->toEqual(15);
+});
+
+it('excludes null values in not_contains mode', function () {
+    expect(Post::filter(['type_nullable_not_contains' => ['__null__']])->count())->toEqual(25)
+        ->and(Post::filter(['type_nullable_not_contains' => ['page', '__null__']])->count())->toEqual(10);
+});
+
+it('adds the null option to optionsWithNull only', function () {
+    $filter = (new TypeFilter)->nullable();
+
+    expect($filter->isNullable())->toBeTrue()
+        ->and($filter->options())->toBe(['page', 'post'])
+        ->and($filter->optionsWithNull())->toBe(['None' => '__null__', 'page', 'post']);
+});
+
+it('does not expose the null option without nullable', function () {
+    $filter = new TypeFilter;
+
+    expect($filter->isNullable())->toBeFalse()
+        ->and($filter->optionsWithNull())->toBe(['page', 'post']);
+});
+
+it('allows a custom null label', function () {
+    $filter = (new TypeFilter)->nullable(label: 'No payment method');
+
+    expect($filter->optionsWithNull())->toBe(['No payment method' => '__null__', 'page', 'post']);
+});
+
+it('is itself a select filter', function () {
+    expect(new TypeFilter)->toBeInstanceOf(SelectFilter::class);
+});


### PR DESCRIPTION
Adds an opt-in `nullable()` option to `SelectFilter` (inherited by `BelongsToFilter` and `EnumFilter`) that exposes a dedicated "none" entry filtering for records where the field is NULL. Selecting it applies whereNull / orWhereNull / whereNotNull depending on the mode.

The feature is opt-in and defaults to false, so existing filters keep their exact behaviour and SQL output. Adds docs and tests.